### PR TITLE
Fix : 소셜 로그인 및 회원가입 전체적인 로직 수정 진행

### DIFF
--- a/YAPP-BE/build.gradle
+++ b/YAPP-BE/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     //gson
     implementation 'com.google.code.gson:gson:2.8.7'
 

--- a/YAPP-BE/src/main/java/yapp/common/config/Const.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/Const.java
@@ -3,8 +3,8 @@ package yapp.common.config;
 public class Const {
 
   public static final String DEFAULT_PASSWORD = "DEFAULT";
-
   public static final int NON_MEMBERS = 0;
   public static final int USE_MEMBERS = 1;
   public static final int QUIT_MEMBERS = 2;
+
 }

--- a/YAPP-BE/src/main/java/yapp/common/config/OpenAPIConfig.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/OpenAPIConfig.java
@@ -21,6 +21,7 @@ public class OpenAPIConfig {
   @Value("${ip.town-scoop}")
   private String SEVER_IP;
   private static final String PROD = "prod";
+  private static final String LOCAL = "local";
   private static final String EXCEPT = "except";
   private final Environment environment;
 
@@ -33,12 +34,38 @@ public class OpenAPIConfig {
   @Bean
   public OpenApiCustomiser customOpenAPI(BuildProperties buildProperties) {
     return openAPI -> {
-      if (!Arrays.asList(environment.getActiveProfiles()).contains(EXCEPT)) {
+      if (Arrays.asList(environment.getActiveProfiles()).contains(PROD)) {
         openAPI.info(
             new Info()
               .title("TownScoop API")
               .version(buildProperties.getVersion())
               .termsOfService("http://" + SEVER_IP + "/")
+              .license(
+                new License().name("Apache 2.0").url("http://springdoc.org")
+              )
+          )
+          .components(
+            openAPI.getComponents().addSecuritySchemes(
+              "bearer",
+              new SecurityScheme()
+                .type(Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+            )
+          )
+          .addSecurityItem(
+            new SecurityRequirement().addList(
+              "bearer", Arrays.asList("read", "write")
+            )
+          );
+      } else if (Arrays.asList(environment.getActiveProfiles()).contains(LOCAL)) {
+        openAPI.info(
+            new Info()
+              .title("TownScoop API")
+              .version(buildProperties.getVersion())
+              .termsOfService("http://localhost:8080/")
               .license(
                 new License().name("Apache 2.0").url("http://springdoc.org")
               )

--- a/YAPP-BE/src/main/java/yapp/common/config/OpenAPIConfig.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/OpenAPIConfig.java
@@ -21,6 +21,7 @@ public class OpenAPIConfig {
   @Value("${ip.town-scoop}")
   private String SEVER_IP;
   private static final String PROD = "prod";
+  private static final String EXCEPT = "except";
   private final Environment environment;
 
   public OpenAPIConfig(
@@ -32,7 +33,7 @@ public class OpenAPIConfig {
   @Bean
   public OpenApiCustomiser customOpenAPI(BuildProperties buildProperties) {
     return openAPI -> {
-      if (!Arrays.asList(environment.getActiveProfiles()).contains(PROD)) {
+      if (!Arrays.asList(environment.getActiveProfiles()).contains(EXCEPT)) {
         openAPI.info(
             new Info()
               .title("TownScoop API")

--- a/YAPP-BE/src/main/java/yapp/common/config/RedisRepositoryConfig.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/RedisRepositoryConfig.java
@@ -1,0 +1,40 @@
+package yapp.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisRepositoryConfig {
+
+  private final RedisProperties redisProperties;
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}

--- a/YAPP-BE/src/main/java/yapp/common/config/SecurityConfig.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -32,6 +33,7 @@ import yapp.domain.member.repository.MemberRefreshTokenRepository;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   private final CorsProperties corsProperties;
+  private final RedisTemplate redisTemplate;
   private final AppProperties appProperties;
   private final AuthTokenProvider tokenProvider;
   private final CustomUserDetailsService userDetailsService;
@@ -67,7 +69,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         "/**/*.css", "/**/*.js"
       )
       .permitAll()
-      .antMatchers("/auth/token", "/oauth2/**", "/auth/**")
+      .antMatchers("/auth/token", "/oauth2/**", "/auth/**", "/health", "/oauth/redirect")
       .permitAll() // Security 허용 Url      .antMatchers("/login").permitAll()
       .antMatchers("/register")
       .permitAll()
@@ -121,7 +123,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Bean
   public TokenAuthenticationFilter tokenAuthenticationFilter() {
-    return new TokenAuthenticationFilter(tokenProvider);
+    return new TokenAuthenticationFilter(tokenProvider, redisTemplate);
   }
 
   @Bean

--- a/YAPP-BE/src/main/java/yapp/common/config/SecurityConfig.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/SecurityConfig.java
@@ -17,13 +17,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import yapp.common.oauth.entity.RoleType;
-import yapp.common.oauth.exception.RestAuthenticationEntryPoint;
 import yapp.common.oauth.filter.TokenAuthenticationFilter;
 import yapp.common.oauth.handler.OAuth2AuthenticationFailureHandler;
 import yapp.common.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import yapp.common.oauth.handler.TokenAccessDeniedHandler;
 import yapp.common.oauth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
-import yapp.common.oauth.service.CustomOAuth2UserService;
 import yapp.common.oauth.service.CustomUserDetailsService;
 import yapp.common.oauth.token.AuthTokenProvider;
 import yapp.domain.member.repository.MemberRefreshTokenRepository;
@@ -37,7 +35,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   private final AppProperties appProperties;
   private final AuthTokenProvider tokenProvider;
   private final CustomUserDetailsService userDetailsService;
-  private final CustomOAuth2UserService oAuth2UserService;
   private final TokenAccessDeniedHandler tokenAccessDeniedHandler;
   private final MemberRefreshTokenRepository memberRefreshTokenRepository;
 
@@ -69,7 +66,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         "/**/*.css", "/**/*.js"
       )
       .permitAll()
-      .antMatchers("/auth/token", "/oauth2/**", "/auth/**", "/health", "/oauth/redirect")
+      .antMatchers(
+        "/auth/token", "/oauth2/**", "/auth/**", "/health", "/oauth/redirect", "/auth/login")
       .permitAll() // Security 허용 Url      .antMatchers("/login").permitAll()
       .antMatchers("/register")
       .permitAll()
@@ -91,22 +89,23 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       .authenticated()
       .and()
       .exceptionHandling()
-      .authenticationEntryPoint(new RestAuthenticationEntryPoint())
-      .accessDeniedHandler(tokenAccessDeniedHandler)
-      .and()
-      .oauth2Login()
-      .authorizationEndpoint()
-      .baseUri("/oauth2/authorization")
-      .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository())
-      .and()
-      .redirectionEndpoint()
-      .baseUri("/oauth2/callback/*")
-      .and()
-      .userInfoEndpoint()
-      .userService(oAuth2UserService)
-      .and()
-      .successHandler(oAuth2AuthenticationSuccessHandler())
-      .failureHandler(oAuth2AuthenticationFailureHandler());
+//      .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+      .accessDeniedHandler(tokenAccessDeniedHandler);
+//      .and()
+//      .oauth2Login()
+//      .authorizationEndpoint()
+//      .baseUri("/oauth2/authorization")
+//      .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository())
+//      .and()
+//      .redirectionEndpoint()
+//      .baseUri("/oauth2/callback/*")
+//      .and()
+//      .userInfoEndpoint()
+//      .userService(oAuth2UserService)
+//      .and()
+//      .successHandler(oAuth2AuthenticationSuccessHandler())
+//      .failureHandler(oAuth2AuthenticationFailureHandler());
+
     http.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
   }
 

--- a/YAPP-BE/src/main/java/yapp/common/oauth/controller/AuthController.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package yapp.common.oauth.controller;
 
 import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ACCESS_TOKEN;
+import static yapp.common.oauth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository.REFRESH_TOKEN;
 
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,10 +19,13 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yapp.common.config.AppProperties;
+import yapp.common.config.Const;
 import yapp.common.oauth.entity.RoleType;
+import yapp.common.oauth.service.AuthService;
 import yapp.common.oauth.token.AuthToken;
 import yapp.common.oauth.token.AuthTokenProvider;
 import yapp.common.response.ApiResponse;
@@ -29,6 +33,7 @@ import yapp.common.response.ApiResponseHeader;
 import yapp.common.security.CurrentAuthPrincipal;
 import yapp.common.utils.CookieUtil;
 import yapp.common.utils.HeaderUtil;
+import yapp.domain.member.dto.request.MemberSignInRequest;
 import yapp.domain.member.entitiy.MemberRefreshToken;
 import yapp.domain.member.repository.MemberRefreshTokenRepository;
 
@@ -38,22 +43,58 @@ import yapp.domain.member.repository.MemberRefreshTokenRepository;
 @RequestMapping("/auth")
 public class AuthController {
 
+  private final AuthService authService;
   private final AppProperties appProperties;
   private final AuthTokenProvider authTokenProvider;
   private final RedisTemplate redisTemplate;
   private final MemberRefreshTokenRepository memberRefreshTokenRepository;
-  private final static String REFRESH_TOKEN = "refresh_token";
 
   public AuthController(
+    AuthService authService,
     AppProperties appProperties,
     AuthTokenProvider authTokenProvider,
     RedisTemplate redisTemplate,
     MemberRefreshTokenRepository memberRefreshTokenRepository
   ) {
+    this.authService = authService;
     this.appProperties = appProperties;
     this.authTokenProvider = authTokenProvider;
     this.redisTemplate = redisTemplate;
     this.memberRefreshTokenRepository = memberRefreshTokenRepository;
+  }
+
+  @PostMapping("/login")
+  @Operation(summary = "소셜 로그인(카카오, 애플)")
+  @Tag(name = "[화면]-로그인/회원가입")
+  public ApiResponse login(
+    HttpServletRequest request,
+    HttpServletResponse response,
+    @RequestBody MemberSignInRequest memberSignInRequest
+  ) {
+
+    Map<String, String> result = authService.login(memberSignInRequest);
+    int registerCheck = Integer.parseInt(result.get("register_check"));
+
+    switch (registerCheck) {
+      case Const.USE_MEMBERS:
+        long refreshTokenExpiry = Long.parseLong(result.get("refresh_token_expiry"));
+        int cookieMaxAge = (int) refreshTokenExpiry / 60;
+        int cookieMaxAgeForAccess = (int) appProperties.getAuth().getTokenExpiry() / 1000;
+
+        // access_token 담기
+        CookieUtil.deleteCookie(request, response, ACCESS_TOKEN);
+        CookieUtil.addCookieForAccess(
+          response, ACCESS_TOKEN, result.get("access_token"), cookieMaxAgeForAccess);
+
+        // refresh_token 담기
+        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+        CookieUtil.addCookie(response, REFRESH_TOKEN, result.get("refresh_token"), cookieMaxAge);
+
+        return new ApiResponse(new ApiResponseHeader(200, "회원 계정입니다."), result);
+      case Const.NON_MEMBERS:
+        return new ApiResponse(new ApiResponseHeader(400, "비회원 계정입니다."), result);
+    }
+    return ApiResponse.fail();
   }
 
   @PostMapping("/login/confirm")
@@ -115,7 +156,7 @@ public class AuthController {
         CookieUtil.deleteCookie(request, response, ACCESS_TOKEN);
         CookieUtil.addCookieForAccess(
           response, ACCESS_TOKEN, newAccessToken.getToken(), cookieMaxAgeForAccess);
-        
+
         return ApiResponse.success("access_token", newAccessToken);
       }
       return ApiResponse.notEqualRefreshToken();

--- a/YAPP-BE/src/main/java/yapp/common/oauth/controller/AuthController.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/controller/AuthController.java
@@ -1,15 +1,22 @@
 package yapp.common.oauth.controller;
 
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.ACCESS_TOKEN;
+
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +25,7 @@ import yapp.common.oauth.entity.RoleType;
 import yapp.common.oauth.token.AuthToken;
 import yapp.common.oauth.token.AuthTokenProvider;
 import yapp.common.response.ApiResponse;
+import yapp.common.response.ApiResponseHeader;
 import yapp.common.security.CurrentAuthPrincipal;
 import yapp.common.utils.CookieUtil;
 import yapp.common.utils.HeaderUtil;
@@ -31,17 +39,20 @@ import yapp.domain.member.repository.MemberRefreshTokenRepository;
 public class AuthController {
 
   private final AppProperties appProperties;
-  private final AuthTokenProvider tokenProvider;
+  private final AuthTokenProvider authTokenProvider;
+  private final RedisTemplate redisTemplate;
   private final MemberRefreshTokenRepository memberRefreshTokenRepository;
   private final static String REFRESH_TOKEN = "refresh_token";
 
   public AuthController(
     AppProperties appProperties,
-    AuthTokenProvider tokenProvider,
+    AuthTokenProvider authTokenProvider,
+    RedisTemplate redisTemplate,
     MemberRefreshTokenRepository memberRefreshTokenRepository
   ) {
     this.appProperties = appProperties;
-    this.tokenProvider = tokenProvider;
+    this.authTokenProvider = authTokenProvider;
+    this.redisTemplate = redisTemplate;
     this.memberRefreshTokenRepository = memberRefreshTokenRepository;
   }
 
@@ -60,47 +71,55 @@ public class AuthController {
   @PostMapping("/reissue/token")
   @Operation(summary = "access_token 재발급")
   public ApiResponse reissueRefreshToken(
-    HttpServletRequest request
+    HttpServletRequest request,
+    HttpServletResponse response
   ) {
     String accessToken = HeaderUtil.getAccessToken(request);
+    String isUnable = (String) redisTemplate.opsForValue().get(accessToken);
+    if (StringUtils.hasText(isUnable)) {
+      return new ApiResponse(new ApiResponseHeader(401, "사용 불가능한 토큰입니다"), null);
+    }
+
     String refreshToken = CookieUtil.getCookie(request, REFRESH_TOKEN)
       .map(Cookie::getValue)
       .orElse((null));
-    AuthToken authToken = tokenProvider.convertAuthToken(accessToken);
+    AuthToken authToken = authTokenProvider.convertAuthToken(accessToken);
 
     Date now = new Date();
-    Claims claims = authToken.getExpiredTokenClaims();
-    if (claims == null) {
-      return ApiResponse.notExpiredTokenYet();
-    }
+    Claims claims = authToken.getTokenClaims();
     String memberId = claims.getSubject();
-    AuthToken authRefreshToken = tokenProvider.convertAuthToken(refreshToken);
-    RoleType roleType = RoleType.of(claims.get("role", String.class));
+    AuthToken authRefreshToken = authTokenProvider.convertAuthToken(refreshToken);
 
-    if (!authToken.validate()) {
-      log.info("만료된 Access 토큰입니다. 재발급이 필요합니다.");
-      if (authRefreshToken.validate()) {
-        log.info("유효한 Refresh 토큰입니다.");
+    if (authRefreshToken.validate()) {
 
-        MemberRefreshToken memberRefreshToken = memberRefreshTokenRepository.findByMemberIdAndRefreshToken(
-          memberId, refreshToken);
-        if (memberRefreshToken == null) {
-          log.info("Refresh 토큰이 null 입니다.");
-          return ApiResponse.invalidRefreshToken();
-        }
-        if (memberRefreshToken.getRefreshToken().equals(refreshToken)) {
-          log.info("access_token 재발급!");
-          AuthToken newAccessToken = tokenProvider.createAuthToken(
-            memberId,
-            roleType.getCode(),
-            new Date(now.getTime() + appProperties.getAuth().getTokenExpiry())
-          );
-          return ApiResponse.success("access_token", newAccessToken);
-        }
+      Optional<MemberRefreshToken> memberRefreshToken = memberRefreshTokenRepository.findByMemberIdAndRefreshToken(
+        memberId, refreshToken);
+      if (memberRefreshToken.isEmpty()) {
+        log.info("Refresh 토큰이 null 입니다.");
         return ApiResponse.invalidRefreshToken();
       }
-      return ApiResponse.invalidRefreshToken();
+      if (memberRefreshToken.get().getRefreshToken().equals(refreshToken)) {
+        //기존 토큰 사용 제한
+        Long expiration = authTokenProvider.getExpiration(accessToken);
+        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+
+        //새 토큰 발급
+        AuthToken newAccessToken = authTokenProvider.createAuthToken(
+          memberId,
+          RoleType.USER.getCode(),
+          new Date(now.getTime() + appProperties.getAuth().getTokenExpiry())
+        );
+
+        //기존 사용하던 쿠키 삭제 후 새 토큰 저장
+        int cookieMaxAgeForAccess = (int) appProperties.getAuth().getTokenExpiry() / 1000;
+        CookieUtil.deleteCookie(request, response, ACCESS_TOKEN);
+        CookieUtil.addCookieForAccess(
+          response, ACCESS_TOKEN, newAccessToken.getToken(), cookieMaxAgeForAccess);
+        
+        return ApiResponse.success("access_token", newAccessToken);
+      }
+      return ApiResponse.notEqualRefreshToken();
     }
-    return ApiResponse.success("access_token", accessToken);
+    return ApiResponse.expiredRefreshToken();
   }
 }

--- a/YAPP-BE/src/main/java/yapp/common/oauth/entity/AppleOAuth2UserInfo.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/entity/AppleOAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package yapp.common.oauth.entity;
+
+import java.util.Map;
+
+public class AppleOAuth2UserInfo extends OAuth2UserInfo {
+
+  public AppleOAuth2UserInfo(Map<String, Object> attributes) {
+    super(attributes);
+  }
+
+  @Override
+  public String getMemberId() {
+    return null;
+  }
+
+  @Override
+  public String getNickname() {
+    return null;
+  }
+
+  @Override
+  public String getEmail() {
+    return null;
+  }
+}

--- a/YAPP-BE/src/main/java/yapp/common/oauth/entity/OAuth2UserInfoFactory.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/entity/OAuth2UserInfoFactory.java
@@ -10,6 +10,8 @@ public class OAuth2UserInfoFactory {
     switch (providerType) {
       case KAKAO:
         return new KakaoOAuth2UserInfo(attributes);
+      case APPLE:
+        return new AppleOAuth2UserInfo(attributes);
       default:
         throw new IllegalArgumentException("유효하지 않는 계정 타입 입니다.");
     }

--- a/YAPP-BE/src/main/java/yapp/common/oauth/filter/TokenAuthenticationFilter.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/filter/TokenAuthenticationFilter.java
@@ -7,8 +7,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import yapp.common.oauth.token.AuthToken;
@@ -19,6 +21,8 @@ import yapp.common.utils.HeaderUtil;
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
   private final AuthTokenProvider tokenProvider;
+
+  private final RedisTemplate redisTemplate;
 
   @Override
   protected void doFilterInternal(
@@ -31,8 +35,13 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     AuthToken token = tokenProvider.convertAuthToken(tokenStr);
 
     if (StringUtils.hasText(tokenStr) && token.validate()) {
-      Authentication authentication = tokenProvider.getAuthentication(token);
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      String isLogout = (String) redisTemplate.opsForValue().get(tokenStr);
+
+      if (ObjectUtils.isEmpty(isLogout)) {
+        Authentication authentication = tokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
     }
 
     filterChain.doFilter(request, response);

--- a/YAPP-BE/src/main/java/yapp/common/oauth/filter/TokenAuthenticationFilter.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/filter/TokenAuthenticationFilter.java
@@ -35,7 +35,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     AuthToken token = tokenProvider.convertAuthToken(tokenStr);
 
     if (StringUtils.hasText(tokenStr) && token.validate()) {
-
       String isLogout = (String) redisTemplate.opsForValue().get(tokenStr);
 
       if (ObjectUtils.isEmpty(isLogout)) {
@@ -43,7 +42,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
       }
     }
-
     filterChain.doFilter(request, response);
   }
 }

--- a/YAPP-BE/src/main/java/yapp/common/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -57,8 +57,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
       return;
     }
 
-    log.info("로그인 성공성공성공 ");
-
     clearAuthenticationAttributes(request, response);
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
@@ -138,16 +136,16 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     int cookieMaxAge = (int) refreshTokenExpiry / 60;
     int cookieMaxAgeForAccess = (int) appProperties.getAuth().getTokenExpiry() / 1000;
 
-        /*
-        Access Token 저장
-         */
+    /*
+    Access Token 저장
+     */
     CookieUtil.deleteCookie(request, response, ACCESS_TOKEN);
     CookieUtil.addCookieForAccess(
       response, ACCESS_TOKEN, accessToken.getToken(), cookieMaxAgeForAccess);
 
-        /*
-        Refresh Token 저장
-         */
+    /*
+    Refresh Token 저장
+     */
     CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
     CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken.getToken(), cookieMaxAge);
 

--- a/YAPP-BE/src/main/java/yapp/common/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -74,6 +74,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         "Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
     }
 
+    log.info("로그인 데이터를 받고 여기로 오는 경우는 없을 거 같다!");
+
     String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
 
     OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
@@ -109,6 +111,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
       appProperties.getAuth().getTokenSecret(),
       new Date(now.getTime() + refreshTokenExpiry)
     );
+    log.info("access 토큰 정보 : {}", accessToken.getToken());
+    log.info("refresh 토큰 정보 : {}", refreshToken.getToken());
 
     log.info(
       "[determineTargetUrl] refreshToken!! id, expiredTokenClaims 생성 : {}, {}, {}",

--- a/YAPP-BE/src/main/java/yapp/common/oauth/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -31,7 +31,7 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository implements
     if (authorizationRequest == null) {
       CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
       CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-      CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+//      CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
       return;
     }
 
@@ -65,6 +65,6 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository implements
   ) {
     CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
     CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-    CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+//    CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
   }
 }

--- a/YAPP-BE/src/main/java/yapp/common/oauth/service/AuthService.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/service/AuthService.java
@@ -1,0 +1,122 @@
+package yapp.common.oauth.service;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yapp.common.config.AppProperties;
+import yapp.common.config.Const;
+import yapp.common.oauth.token.AuthToken;
+import yapp.common.oauth.token.AuthTokenProvider;
+import yapp.domain.member.dto.request.MemberSignInRequest;
+import yapp.domain.member.entitiy.MemberPrincipal;
+import yapp.domain.member.entitiy.MemberRefreshToken;
+import yapp.domain.member.repository.MemberRefreshTokenRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+  private final AppProperties appProperties;
+  private final AuthTokenProvider authTokenProvider;
+  private final AuthenticationManager authenticationManager;
+  private final MemberRefreshTokenRepository memberRefreshTokenRepository;
+
+  public AuthService(
+    AppProperties appProperties,
+    AuthTokenProvider authTokenProvider,
+    AuthenticationManager authenticationManager,
+    MemberRefreshTokenRepository memberRefreshTokenRepository
+  ) {
+    this.appProperties = appProperties;
+    this.authTokenProvider = authTokenProvider;
+    this.authenticationManager = authenticationManager;
+    this.memberRefreshTokenRepository = memberRefreshTokenRepository;
+  }
+
+  @Transactional
+  public Map<String, String> login(MemberSignInRequest memberSignInRequest) {
+
+    UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+      memberSignInRequest.getMemberId(),
+      Const.DEFAULT_PASSWORD
+    );
+
+    Authentication authentication = authenticationManager.authenticate(token);
+
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    Date now = new Date();
+    AuthToken accessToken = getAuthToken(memberSignInRequest.getMemberId(), authentication);
+
+    long refreshTokenExpiry = appProperties.getAuth().getRefreshTokenExpiry();
+    int cookieMaxAge = (int) refreshTokenExpiry / 60;
+
+    AuthToken refreshToken = getRefreshToken(now, refreshTokenExpiry);
+
+    MemberRefreshToken memberRefreshToken = memberRefreshTokenRepository.findByMemberId(
+      memberSignInRequest.getMemberId());
+
+    extracted(memberSignInRequest.getMemberId(), refreshToken, memberRefreshToken);
+
+    return getStringStringMap(
+      accessToken, refreshTokenExpiry, cookieMaxAge, refreshToken);
+  }
+
+  @NotNull
+  private static Map<String, String> getStringStringMap(
+    AuthToken accessToken,
+    long refreshTokenExpiry,
+    int cookieMaxAge,
+    AuthToken refreshToken
+  ) {
+    Map<String, String> result = new HashMap<>();
+    result.put("refresh_token_expiry", String.valueOf(refreshTokenExpiry));
+    result.put("register_check", String.valueOf(Const.USE_MEMBERS));
+    result.put("access_token", accessToken.getToken());
+    result.put("refresh_token", refreshToken.getToken());
+    result.put("cookie_max_age", String.valueOf(cookieMaxAge));
+    return result;
+  }
+
+  private void extracted(
+    String memberId,
+    AuthToken refreshToken,
+    MemberRefreshToken memberRefreshToken
+  ) {
+    if (memberRefreshToken == null) {
+      memberRefreshToken = new MemberRefreshToken(memberId, refreshToken.getToken());
+      this.memberRefreshTokenRepository.saveAndFlush(memberRefreshToken);
+    } else {
+      memberRefreshToken.setRefreshToken(refreshToken.getToken());
+      this.memberRefreshTokenRepository.saveAndFlush(memberRefreshToken);
+    }
+  }
+
+  private AuthToken getRefreshToken(
+    Date now,
+    long refreshTokenExpiry
+  ) {
+    return authTokenProvider.createAuthToken(
+      appProperties.getAuth().getTokenSecret(),
+      new Date(now.getTime() + refreshTokenExpiry)
+    );
+  }
+
+  private AuthToken getAuthToken(
+    String memberId,
+    Authentication authentication
+  ) {
+    Date now = new Date();
+    String code = ((MemberPrincipal) authentication.getPrincipal()).getRoleType().getCode();
+    Date expired = new Date(now.getTime() + appProperties.getAuth().getTokenExpiry());
+
+    return this.authTokenProvider.createAuthToken(memberId, code, expired);
+  }
+}

--- a/YAPP-BE/src/main/java/yapp/common/oauth/service/CustomOAuth2UserService.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/service/CustomOAuth2UserService.java
@@ -56,11 +56,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             + "계정 타입이 일치하지 않습니다."
         );
       }
-      log.info("로그인을 한다면 여길 타고 흘러 갈듯!! 회원정보 조회해보자(이미 회원) : {}", savedMember.get().getEmail());
       updateMember(savedMember.get(), memberInfo);
     } else {
-      savedMember = Optional.of(createMember(memberInfo, providerType)); // 회원가입 할때 로직 수정 필요!!
-      log.info("로그인을 한다면 여길 타고 흘러 갈듯!! 회원정보 조회해보자(회원 아님) : {}", savedMember.get().getEmail());
+      savedMember = Optional.of(createMember(memberInfo, providerType));
     }
 
     return MemberPrincipal.create(savedMember.get(), user.getAttributes());

--- a/YAPP-BE/src/main/java/yapp/common/oauth/service/CustomUserDetailsService.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package yapp.common.oauth.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -9,6 +10,7 @@ import yapp.domain.member.entitiy.Member;
 import yapp.domain.member.entitiy.MemberPrincipal;
 import yapp.domain.member.repository.MemberRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
@@ -18,7 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     Member member = memberRepository.findByMemberId(username)
-      .orElseThrow(() -> new UsernameNotFoundException("회원 ID로 계정을 조회할 수 없다."));
+      .orElseThrow(() -> new UsernameNotFoundException("등록된 회원이 아닙니다"));
     return MemberPrincipal.create(member);
   }
 }

--- a/YAPP-BE/src/main/java/yapp/common/oauth/token/AuthToken.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/token/AuthToken.java
@@ -9,11 +9,9 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import java.security.Key;
 import java.util.Date;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 public class AuthToken {
 
   @Getter
@@ -23,6 +21,14 @@ public class AuthToken {
   @Getter
   private String id;
   private static final String AUTHORITIES_KEY = "role";
+
+  public AuthToken(
+    String token,
+    Key key
+  ) {
+    this.token = token;
+    this.key = key;
+  }
 
   AuthToken(
     String id,

--- a/YAPP-BE/src/main/java/yapp/common/oauth/token/AuthTokenProvider.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/token/AuthTokenProvider.java
@@ -1,6 +1,7 @@
 package yapp.common.oauth.token;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Arrays;
@@ -42,6 +43,18 @@ public class AuthTokenProvider {
 
   public AuthToken convertAuthToken(String token) {
     return new AuthToken(token, key);
+  }
+
+  public Long getExpiration(String accessToken) {
+    Date expiration = Jwts.parserBuilder()
+      .setSigningKey(key)
+      .build()
+      .parseClaimsJws(accessToken)
+      .getBody()
+      .getExpiration();
+
+    Long now = new Date().getTime();
+    return (expiration.getTime() - now);
   }
 
   public Authentication getAuthentication(AuthToken authToken) {

--- a/YAPP-BE/src/main/java/yapp/common/oauth/token/AuthTokenProvider.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/token/AuthTokenProvider.java
@@ -9,15 +9,17 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import yapp.common.exception.TokenValidFailedException;
 
 @Slf4j
-public class AuthTokenProvider {
+public class AuthTokenProvider implements AuthenticationProvider {
 
   private final Key key;
   private static final String AUTHORITIES_KEY = "role";
@@ -74,5 +76,16 @@ public class AuthTokenProvider {
     } else {
       throw new TokenValidFailedException();
     }
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+    return null;
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return authentication.equals(UsernamePasswordAuthenticationToken.class);
   }
 }

--- a/YAPP-BE/src/main/java/yapp/common/response/ApiResponse.java
+++ b/YAPP-BE/src/main/java/yapp/common/response/ApiResponse.java
@@ -19,6 +19,8 @@ public class ApiResponse<T> {
   private final static String INVALID_REFRESH_TOKEN = "유효하지 않은 REFRESH TOKEN 입니다.";
   private final static String NOT_EXPIRED_TOKEN_YET = "아직 토큰이 만료되지 않았습니다.";
   private final static String FAILED_SIGNUP = "회원 가입에 실패하였습니다.";
+  private final static String EXPIRED_REFRESH_TOKEN = "만료된 REFRESH TOKEN 입니다. 로그인을 다시 진행해주세요";
+  private final static String NOT_EQUAL_REFRESH_TOKEN = "REFRESH TOKEN 정보가 일치하지 않습니다.";
 
   private final ApiResponseHeader header;
   private final Map<String, T> body;
@@ -51,6 +53,14 @@ public class ApiResponse<T> {
 
   public static <T> ApiResponse<T> invalidRefreshToken() {
     return new ApiResponse(new ApiResponseHeader(FAILED, INVALID_REFRESH_TOKEN), null);
+  }
+
+  public static <T> ApiResponse<T> expiredRefreshToken() {
+    return new ApiResponse(new ApiResponseHeader(FAILED, EXPIRED_REFRESH_TOKEN), null);
+  }
+
+  public static <T> ApiResponse<T> notEqualRefreshToken() {
+    return new ApiResponse(new ApiResponseHeader(FAILED, NOT_EQUAL_REFRESH_TOKEN), null);
   }
 
   public static <T> ApiResponse<T> notExpiredTokenYet() {

--- a/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
@@ -85,6 +85,28 @@ public class MemberController {
       : ApiResponse.success("exist_confirm", result);
   }
 
+  @GetMapping("/check/register")
+  @PreAuthorize("hasRole('USER')")
+  @Operation(summary = "회원 가입 여부")
+  @Tag(name = "[화면]-회원가입")
+  public ApiResponse checkRegisterMember(
+    @CurrentAuthPrincipal User memberPrincipal
+  ) {
+    Map<String, Integer> result = new HashMap<>();
+    int isRegister = this.memberService.checkRegister(memberPrincipal.getUsername());
+    switch (isRegister) {
+      case 0:
+        result.put("register_check", Const.NON_MEMBERS);
+        return new ApiResponse(new ApiResponseHeader(200, "비회원 입니다"), result);
+      case 1:
+        result.put("register_check", Const.USE_MEMBERS);
+        return new ApiResponse(new ApiResponseHeader(200, "회원 입니다"), result);
+      default:
+        result.put("register_check", Const.QUIT_MEMBERS);
+        return new ApiResponse(new ApiResponseHeader(200, "탈퇴(휴면)회원 입니다"), result);
+    }
+  }
+
   @GetMapping("/logout")
   @PreAuthorize("hasRole('USER')")
   @Operation(summary = "로그 아웃")

--- a/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
@@ -56,15 +56,12 @@ public class MemberController {
   }
 
   @PostMapping("/signup")
-  @PreAuthorize("hasRole('USER')")
   @Operation(summary = "회원가입")
-  @Tag(name = "[화면]-로그인")
+  @Tag(name = "[화면]-로그인/회원가입")
   public ApiResponse socialSignUp(
-    @CurrentAuthPrincipal User memberPrincipal,
     @RequestBody MemberSignUpRequest memberSignUpRequest
   ) {
-    String memberId = this.memberService.memberSignUp(
-      memberSignUpRequest, memberPrincipal.getUsername());
+    String memberId = this.memberService.memberSignUp(memberSignUpRequest);
     if (StringUtils.hasText(memberId)) {
       return ApiResponse.success("signup", true);
     }
@@ -73,7 +70,7 @@ public class MemberController {
 
   @GetMapping("/check/nickname")
   @Operation(summary = "닉네임 중복 확인")
-  @Tag(name = "[화면]-회원가입")
+  @Tag(name = "[화면]-로그인/회원가입")
   public ApiResponse checkNickname(
     @RequestParam(name = "nickname") String nickname
   ) {
@@ -88,7 +85,7 @@ public class MemberController {
   @GetMapping("/check/register")
   @PreAuthorize("hasRole('USER')")
   @Operation(summary = "회원 가입 여부")
-  @Tag(name = "[화면]-회원가입")
+  @Tag(name = "[화면]-로그인/회원가입")
   public ApiResponse checkRegisterMember(
     @CurrentAuthPrincipal User memberPrincipal
   ) {

--- a/YAPP-BE/src/main/java/yapp/domain/member/converter/MemberConverter.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/converter/MemberConverter.java
@@ -3,14 +3,21 @@ package yapp.domain.member.converter;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import yapp.common.config.Const;
 import yapp.common.domain.Location;
+import yapp.common.oauth.entity.RoleType;
+import yapp.domain.member.dto.request.MemberSignUpRequest;
 import yapp.domain.member.dto.response.MemberInfoResponse;
 import yapp.domain.member.entitiy.Member;
 
 @Component
 @RequiredArgsConstructor
 public class MemberConverter {
+
+  private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
   public Optional<MemberInfoResponse> toMemberInfo(
     Member member,
@@ -26,5 +33,23 @@ public class MemberConverter {
       .providerType(member.getProviderType())
       .locationList(locationList)
       .build());
+  }
+
+  public Member toEntity(
+    MemberSignUpRequest memberSignUpRequest
+  ) {
+    Member member = Member.builder()
+      .memberId(memberSignUpRequest.getMemberId())
+      .email(memberSignUpRequest.getEmail())
+      .nickname(memberSignUpRequest.getNickname())
+      .providerType(memberSignUpRequest.getProviderType())
+      .resident(memberSignUpRequest.getResident())
+      .useAgreeYn(memberSignUpRequest.getUseAgreeYn())
+      .privacyAgreeYn(memberSignUpRequest.getPrivacyAgreeYn())
+      .useStatus(Const.USE_MEMBERS)
+      .roleType(RoleType.USER)
+      .build();
+    member.encodeDefaultPassword(passwordEncoder);
+    return member;
   }
 }

--- a/YAPP-BE/src/main/java/yapp/domain/member/dto/request/MemberSignInRequest.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/dto/request/MemberSignInRequest.java
@@ -1,0 +1,16 @@
+package yapp.domain.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import yapp.common.oauth.entity.ProviderType;
+
+@Getter
+@Setter
+@Builder
+public class MemberSignInRequest {
+  String memberId;
+  ProviderType providerType;
+  String email;
+  String nickname;
+}

--- a/YAPP-BE/src/main/java/yapp/domain/member/dto/request/MemberSignUpRequest.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/dto/request/MemberSignUpRequest.java
@@ -10,6 +10,8 @@ import yapp.domain.member.entitiy.Resident;
 @Setter
 @Builder
 public class MemberSignUpRequest {
+  private String memberId;
+  private String email;
   private String nickname;
   private ProviderType providerType;
   private Long objectId;

--- a/YAPP-BE/src/main/java/yapp/domain/member/entitiy/Member.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/entitiy/Member.java
@@ -13,13 +13,15 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import yapp.common.config.Const;
 import yapp.common.domain.BaseEntity;
 import yapp.common.oauth.entity.ProviderType;
 import yapp.common.oauth.entity.RoleType;
-import yapp.domain.member.dto.request.MemberSignUpRequest;
 
 @Entity
 @Getter
@@ -41,7 +43,7 @@ public class Member extends BaseEntity {
   private String email;
 
   @Column(name = "nickname")
-  private String nickname; // 중복 확인 로직 필요
+  private String nickname;
 
   @NotNull
   @Size(max = 128)
@@ -51,7 +53,7 @@ public class Member extends BaseEntity {
   @Column(name = "provider_type", length = 20)
   @Enumerated(EnumType.STRING)
   @NotNull
-  private ProviderType providerType; //이 값으로 소셜 로그인간 이메일 구분한다.
+  private ProviderType providerType;
 
   @Column(name = "role_type", length = 20)
   @Enumerated(EnumType.STRING)
@@ -82,20 +84,22 @@ public class Member extends BaseEntity {
     this.nickname = nickname;
   }
 
-  public void changeMemberStatus(
-    int useStatus
+  public void checkPassword(
+    PasswordEncoder passwordEncoder,
+    String credentials
   ) {
-    this.useStatus = useStatus;
+    if (!passwordEncoder.matches(credentials, this.password)) {
+      throw new BadCredentialsException("Bad credential");
+    }
   }
 
-  public void setSignUp(MemberSignUpRequest memberSignUpRequest) {
-    this.nickname = memberSignUpRequest.getNickname();
-    this.providerType = memberSignUpRequest.getProviderType();
-    this.resident = memberSignUpRequest.getResident();
-    this.useAgreeYn = memberSignUpRequest.getUseAgreeYn();
-    this.privacyAgreeYn = memberSignUpRequest.getPrivacyAgreeYn();
+  public void encodeDefaultPassword(
+    PasswordEncoder passwordEncoder
+  ) {
+    this.password = passwordEncoder.encode(Const.DEFAULT_PASSWORD);
   }
 
+  @Builder
   public Member(
     String memberId,
     String email,

--- a/YAPP-BE/src/main/java/yapp/domain/member/entitiy/MemberRefreshToken.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/entitiy/MemberRefreshToken.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import yapp.common.domain.BaseEntity;
 
 @Getter
 @Setter
@@ -20,7 +21,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Entity
 @Table(name = "member_refresh_token")
-public class MemberRefreshToken {
+public class MemberRefreshToken extends BaseEntity {
 
   @JsonIgnore
   @Id

--- a/YAPP-BE/src/main/java/yapp/domain/member/repository/MemberRefreshTokenRepository.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/repository/MemberRefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package yapp.domain.member.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import yapp.domain.member.entitiy.MemberRefreshToken;
@@ -7,9 +8,11 @@ import yapp.domain.member.entitiy.MemberRefreshToken;
 @Repository
 public interface MemberRefreshTokenRepository extends JpaRepository<MemberRefreshToken, Long> {
 
+  void deleteByMemberId(String memberId);
+
   MemberRefreshToken findByMemberId(String memberId);
 
-  MemberRefreshToken findByMemberIdAndRefreshToken(
+  Optional<MemberRefreshToken> findByMemberIdAndRefreshToken(
     String memberId,
     String refreshToken
   );

--- a/YAPP-BE/src/main/java/yapp/domain/member/repository/MemberRepository.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/repository/MemberRepository.java
@@ -10,7 +10,7 @@ import yapp.domain.member.entitiy.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   boolean existsAllByNickname(String nickname);
-
+  
   Optional<Member> findByEmailAndProviderType(
     String memberEmail,
     ProviderType providerType

--- a/YAPP-BE/src/main/java/yapp/domain/member/service/MemberService.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/service/MemberService.java
@@ -72,6 +72,19 @@ public class MemberService {
     return this.memberRepository.save(signUpMember).getMemberId();
   }
 
+  @Transactional
+  public void memberLogout(
+    String accessToken,
+    String memberId
+  ) {
+    // 1. DB refresh 토큰 삭제하기
+    this.memberRefreshTokenRepository.deleteByMemberId(memberId);
+
+    // 2. redis에 access_token 등록
+    Long expiration = authTokenProvider.getExpiration(accessToken);
+    redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+  }
+
   public boolean checkDuplicateNickname(String nickname) {
     return this.memberRepository.existsAllByNickname(nickname);
   }

--- a/YAPP-BE/src/main/java/yapp/domain/member/service/MemberService.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/service/MemberService.java
@@ -1,13 +1,16 @@
 package yapp.domain.member.service;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yapp.common.config.Const;
 import yapp.common.domain.Location;
+import yapp.common.oauth.token.AuthTokenProvider;
 import yapp.common.repository.LocationRepository;
 import yapp.domain.member.converter.MemberConverter;
 import yapp.domain.member.dto.request.MemberSignUpRequest;
@@ -15,6 +18,7 @@ import yapp.domain.member.dto.response.MemberInfoResponse;
 import yapp.domain.member.entitiy.Member;
 import yapp.domain.member.entitiy.MemberWishTown;
 import yapp.domain.member.entitiy.WishStatus;
+import yapp.domain.member.repository.MemberRefreshTokenRepository;
 import yapp.domain.member.repository.MemberRepository;
 import yapp.domain.member.repository.MemberWishTownRepository;
 
@@ -24,19 +28,28 @@ import yapp.domain.member.repository.MemberWishTownRepository;
 public class MemberService {
   private final MemberRepository memberRepository;
   private final MemberWishTownRepository memberWishTownRepository;
+  private final MemberRefreshTokenRepository memberRefreshTokenRepository;
   private final LocationRepository locationRepository;
   private final MemberConverter memberConverter;
+  private final AuthTokenProvider authTokenProvider;
+  private final RedisTemplate<String, String> redisTemplate;
 
   public MemberService(
     MemberRepository memberRepository,
     MemberWishTownRepository memberWishTownRepository,
+    MemberRefreshTokenRepository memberRefreshTokenRepository,
     LocationRepository locationRepository,
-    MemberConverter memberConverter
+    MemberConverter memberConverter,
+    AuthTokenProvider authTokenProvider,
+    RedisTemplate<String, String> redisTemplate
   ) {
     this.memberRepository = memberRepository;
     this.memberWishTownRepository = memberWishTownRepository;
+    this.memberRefreshTokenRepository = memberRefreshTokenRepository;
     this.locationRepository = locationRepository;
     this.memberConverter = memberConverter;
+    this.authTokenProvider = authTokenProvider;
+    this.redisTemplate = redisTemplate;
   }
 
   public MemberInfoResponse getMemberInfo(String memberId) {
@@ -57,7 +70,7 @@ public class MemberService {
     String memberId
   ) {
     Member signUpMember = this.memberRepository.findByMemberId(memberId)
-      .orElseThrow(() -> new UsernameNotFoundException("회원 ID로 계정을 조회할 수 없다."));
+      .orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다."));
 
     signUpMember.setSignUp(memberSignUpRequest);
     signUpMember.changeMemberStatus(Const.USE_MEMBERS);
@@ -70,6 +83,14 @@ public class MemberService {
     }
 
     return this.memberRepository.save(signUpMember).getMemberId();
+  }
+
+  public int checkRegister(
+    String memberId
+  ) {
+    Member member = this.memberRepository.findByMemberId(memberId)
+      .orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다."));
+    return member.getUseStatus();
   }
 
   @Transactional
@@ -88,125 +109,4 @@ public class MemberService {
   public boolean checkDuplicateNickname(String nickname) {
     return this.memberRepository.existsAllByNickname(nickname);
   }
-//  public Map<String, String> getKaKaoAccessToken(String accessCode) {
-//    String accessToken = "";
-//    String refreshToken = "";
-//    String reqURL = "https://kauth.kakao.com/oauth/token";
-//    HashMap<String, String> tokenInfo = new HashMap<>();
-//
-//    try {
-//      URL url = new URL(reqURL);
-//      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-//
-//      //POST 요청을 위해 기본값이 false인 setDoOutput을 true로
-//      conn.setRequestMethod("POST");
-//      conn.setDoOutput(true);
-//
-//      //POST 요청에 필요로 요구하는 파라미터 스트림을 통해 전송
-//      BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
-//      StringBuilder sb = new StringBuilder();
-//      sb.append("grant_type=authorization_code");
-//      sb.append("&client_secret=" + clientSecret);
-//      sb.append("&client_id=" + clientId);
-//      sb.append("&redirect_uri=" + redirectUri);
-//      sb.append("&code=" + accessCode);
-//      bw.write(sb.toString());
-//      bw.flush();
-//
-//      //결과 코드가 200이라면 성공
-//      int responseCode = conn.getResponseCode();
-//      System.out.println("responseCode : " + responseCode);
-//      System.out.println("responseBody : " + conn.getResponseMessage());
-//
-//      //요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
-//      BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-//      String line = "";
-//      String result = "";
-//
-//      while ((line = br.readLine()) != null) {
-//        result += line;
-//      }
-//      System.out.println("response body : " + result);
-//
-//      //Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
-//      JsonParser parser = new JsonParser();
-//      JsonElement element = parser.parse(result);
-//
-//      // 카카오에서 발급해주는 토큰
-//      accessToken = element.getAsJsonObject().get("access_token").getAsString();
-//      refreshToken = element.getAsJsonObject().get("refresh_token").getAsString();
-//
-//      System.out.println("access_token : " + accessToken);
-//      System.out.println("refresh_token : " + refreshToken);
-//
-//      tokenInfo.put("access_token", accessToken);
-//      tokenInfo.put("refresh_token", refreshToken);
-//
-//      br.close();
-//      bw.close();
-//    } catch (IOException e) {
-//      e.printStackTrace();
-//    }
-//    return tokenInfo;
-//  }
-//
-//  public void getTownScoopInfo() {
-//
-//  }
-//
-//  // 카카오에서 발급해주는 토큰으로만 접근가능하다!
-//  public HashMap<String, Object> getKakaoMemberInfo(String accessCode) {
-//
-//    HashMap<String, Object> userInfo = new HashMap<>();
-//    String reqURL = "https://kapi.kakao.com/v2/user/me";
-//    try {
-//      URL url = new URL(reqURL);
-//      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-//      conn.setRequestMethod("POST");
-//      conn.setDoOutput(true);
-//      conn.setRequestProperty("Authorization", "Bearer " + accessCode);
-//      conn.setRequestProperty("client_secret", clientSecret);
-//      conn.setRequestProperty("client_id", clientId);
-//      conn.setRequestProperty("grant_type", "authorization_code");
-//      conn.setRequestProperty("redirect_uri", redirectUri);
-//
-//      int responseCode = conn.getResponseCode();
-//      System.out.println("access_code : " + accessCode);
-//      System.out.println("responseCode : " + responseCode);
-//      System.out.println("responseResponseMessage : " + conn.getResponseMessage());
-//
-//      BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-//
-//      String line = "";
-//      String result = "";
-//
-//      while ((line = br.readLine()) != null) {
-//        result += line;
-//      }
-//      System.out.println("response body : " + result);
-//
-//      JsonParser parser = new JsonParser();
-//      JsonElement element = parser.parse(result);
-//
-//      JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
-//      JsonObject kakao_account = element.getAsJsonObject().get("kakao_account").getAsJsonObject();
-//
-//      String nickname = properties.getAsJsonObject().get("nickname").getAsString();
-//      String email = kakao_account.getAsJsonObject().get("email").getAsString();
-//      String id = element.getAsJsonObject().get("id").getAsString();
-//
-//      userInfo.put("nickname", nickname);
-//      userInfo.put("email", email);
-//      userInfo.put("id", id);
-//
-//    } catch (IOException e) {
-//      e.printStackTrace();
-//    }
-//
-//    return userInfo;
-//  }
-//
-////  public MemberInfoDto getTownMemberInfo() {
-////
-////  }
 }

--- a/YAPP-BE/src/main/java/yapp/health/HealthController.java
+++ b/YAPP-BE/src/main/java/yapp/health/HealthController.java
@@ -2,9 +2,10 @@ package yapp.health;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import yapp.common.response.ApiResponse;
+import yapp.common.response.ApiResponseHeader;
 
 @Tag(name = "네트워크 연결 체크")
 @RestController
@@ -12,7 +13,7 @@ public class HealthController {
 
   @Operation(summary = "헬스 체크")
   @GetMapping("/health")
-  public HttpMethod getCheck() {
-    return HttpMethod.GET;
+  public ApiResponse getCheck() {
+    return new ApiResponse(new ApiResponseHeader(200, "네트워크 연결 성공!!!"), null);
   }
 }

--- a/YAPP-BE/src/main/resources/application-local.yml
+++ b/YAPP-BE/src/main/resources/application-local.yml
@@ -2,12 +2,15 @@ spring:
   config:
     activate:
       on-profile: local
+  redis:
+    host: localhost
+    port: ${REDIS_PORT}
   jpa:
     show-sql: true
     properties:
       hibernate.format_sql: true
   mvc:
-    pathmatch:
+    path match:
       matching-strategy: ant_path_matcher
   security:
     oauth2:
@@ -36,7 +39,7 @@ social-kakao:
   clientSecret: ${CLIENT_SECRET}
 
 cors:
-  allowed-origins: http://localhost:8080
+  allowed-origins: http://localhost:8080,http://localhost:6379
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: '*'
   max-age: 3600

--- a/YAPP-BE/src/main/resources/application-prod.yml
+++ b/YAPP-BE/src/main/resources/application-prod.yml
@@ -2,8 +2,11 @@ spring:
   config:
     activate:
       on-profile: prod
+  redis:
+    host: ${SERVER_IP_ONLY}
+    port: ${REDIS_PORT}
   mvc:
-    pathmatch:
+    path match:
       matching-strategy: ant_path_matcher
   security:
     oauth2:
@@ -41,7 +44,7 @@ app:
       - ${KAKAO_REDIRECT_URL}
 
 cors:
-  allowed-origins: ${ALLOWED_ORIGIN}
+  allowed-origins: ${ALLOWED_ORIGIN},${ALLOWED_REDIS_ORIGIN}
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: '*'
   max-age: 3600


### PR DESCRIPTION
## 📝 PR Summary
client에서 소셜 로그인(카카오, 애플)을 진행하고 해당 계정으로 로그인 API 호출하여 토큰을 발급받도록 수정
- 그 외 전체적인 예외처리 진행

<!-- PR 한줄 요약 -->

#### 🌲 Working Branch

feature/TOWNSCOOP-16

<!-- 작업 브랜치 이름 -->

#### ✅ TODOs

<!-- PR 작업한 내용 -->
- [x] 애플, 카카오 계정으로 로그인 기능 추가
- [x] 로그 아웃 기능(애플, 카카오)
- [x] 서비스 이용 회원 여부 확인 API

### Related Issues

<!-- PR 연관 이슈 -->

- resolves #16 

