### PR TITLE
Refactor: 회원가입 요청시 access, refresh 토큰 발급으로 수정, 회원 정보 조회시 예외처리 로직 추가

### DIFF
--- a/YAPP-BE/src/main/java/yapp/common/oauth/provider/AuthProvider.java
+++ b/YAPP-BE/src/main/java/yapp/common/oauth/provider/AuthProvider.java
@@ -1,0 +1,8 @@
+package yapp.common.oauth.provider;
+
+import java.util.Map;
+
+public interface AuthProvider {
+
+  Map<String, Object> login(String memberId);
+}

--- a/YAPP-BE/src/main/java/yapp/domain/member/converter/MemberConverter.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/converter/MemberConverter.java
@@ -1,7 +1,7 @@
 package yapp.domain.member.converter;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,6 +11,7 @@ import yapp.common.config.Const;
 import yapp.common.domain.Location;
 import yapp.common.oauth.entity.RoleType;
 import yapp.domain.member.dto.request.MemberSignUpRequest;
+import yapp.domain.member.dto.response.LocationInfo;
 import yapp.domain.member.dto.response.MemberInfoResponse;
 import yapp.domain.member.entity.Member;
 import yapp.domain.member.entity.Resident;
@@ -23,12 +24,12 @@ public class MemberConverter {
 
   private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-  public Optional<MemberInfoResponse> toMemberInfo(
+  public MemberInfoResponse toMemberInfo(
     Member member,
     List<Location> locationList,
     TownResident townResident
   ) {
-    return Optional.of(MemberInfoResponse.builder()
+    return MemberInfoResponse.builder()
       .memberId(member.getMemberId())
       .email(member.getEmail())
       .nickname(member.getNickname())
@@ -41,8 +42,16 @@ public class MemberConverter {
       .useAgreeYn(member.getUseAgreeYn().getValue())
       .privacyAgreeYn(member.getPrivacyAgreeYn().getValue())
       .providerType(member.getProviderType())
-      .locationList(locationList)
-      .build());
+      .locationList(locationList
+        .stream()
+        .map(location -> {
+          return new LocationInfo(location.getObjectId(), location.getSidoNm(), location.getSggNm(),
+            location.getAdmNm()
+          );
+        })
+        .collect(Collectors.toList())
+      )
+      .build();
   }
 
   public Member toEntity(

--- a/YAPP-BE/src/main/java/yapp/domain/member/dto/response/LocationInfo.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/dto/response/LocationInfo.java
@@ -1,0 +1,25 @@
+package yapp.domain.member.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LocationInfo {
+  private Long objectId;
+  private String sidoNm;
+  private String sggNm;
+  private String admNm;
+
+  public LocationInfo(
+    Long objectId,
+    String sidoNm,
+    String sggNm,
+    String admNm
+  ) {
+    this.objectId = objectId;
+    this.sidoNm = sidoNm;
+    this.sggNm = sggNm;
+    this.admNm = admNm;
+  }
+}

--- a/YAPP-BE/src/main/java/yapp/domain/member/dto/response/MemberInfoResponse.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/dto/response/MemberInfoResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import yapp.common.domain.Location;
 import yapp.common.oauth.entity.ProviderType;
 import yapp.domain.member.entity.Resident;
 
@@ -19,5 +18,6 @@ public class MemberInfoResponse {
   private Resident resident;
   private boolean useAgreeYn;
   private boolean privacyAgreeYn;
-  private List<Location> locationList;
+  private List<LocationInfo> locationList;
 }
+

--- a/YAPP-BE/src/main/java/yapp/domain/town/entity/TownResident.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/entity/TownResident.java
@@ -64,4 +64,9 @@ public class TownResident extends BaseEntity {
     this.residentYear = residentYear;
     this.residentMonth = residentMonth;
   }
+
+  public static TownResident EmptyResident() {
+    return new TownResident(0L, 0L, "", "", "", 0, 0);
+  }
+
 }


### PR DESCRIPTION
## 📝 PR Summary
회원가입시 로그인 process까지 진행되도록 수정, 회원 정보 조회시 location 불필요한 데이터 반환 정보 제거 및 거주 정보 예외처리 추가
<!-- PR 한줄 요약 -->

#### 🌲 Working Branch

<!-- 작업 브랜치 이름 -->
feature/TOWNSCOOP-47
#### ✅ TODOs

<!-- PR 작업한 내용 -->

- [x] : 회원가입시 access, refresh 토큰 발급으로 수정
- [x] : 회원 정보 조회시 location 불필요한 데이터 반환 정보 제거 및 거주 정보 예외처리 추가

### Related Issues

<!-- PR 연관 이슈 -->

- resolves #47 
