### PR TITLE
Fix: 찜 등록/해제 API 새로운 동네 등록 시 오류 수정

### DIFF
--- a/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
@@ -179,9 +179,8 @@ public class MemberController {
     @CurrentAuthPrincipal User memberPrincipal,
     @RequestParam String object_id
   ) {
-    this.memberService.setMemberWishTown(object_id, memberPrincipal.getUsername());
 
-    return ApiResponse.success("wishTown", true);
+    return ApiResponse.success("wishTown", this.memberService.setMemberWishTown(object_id, memberPrincipal.getUsername()));
   }
 
 

--- a/YAPP-BE/src/main/java/yapp/domain/member/service/MemberService.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/service/MemberService.java
@@ -225,30 +225,34 @@ public class MemberService {
   }
 
   @Transactional
-  public void setMemberWishTown(
+  public String setMemberWishTown(
     String objectId,
     String memberId
   ) {
     Location location = this.locationRepository.getLocationByObjectId(Long.valueOf(objectId))
       .orElseThrow();
+    
+    String msg = "찜 등록";
 
-    MemberWishTown wishTown = this.memberWishTownRepository.getMemberWishTownByMemberIdAndLocation(
-      memberId, location).orElseThrow();
-
-    if (wishTown != null) {
+    try{
+      MemberWishTown wishTown = this.memberWishTownRepository.getMemberWishTownByMemberIdAndLocation(
+        memberId, location).orElseThrow();
 
       if (wishTown.getWishStatus().equals(YES)) {
         wishTown.changeWishStatus(NO);
+        msg = "찜 해제";
       } else {
         wishTown.changeWishStatus(YES);
       }
-    } else {
+    } catch (Exception e){
       memberWishTownRepository.save(MemberWishTown.builder()
         .wishStatus(YES)
         .memberId(memberId)
         .location(location)
         .build());
     }
+
+    return msg;
   }
 
 }


### PR DESCRIPTION
## 📝 PR Summary

<!-- PR 한줄 요약 -->
찜 등록/해제 API DB에 존재하지 않는 새로운 동네 등록 시 오류 발생 수정
#### 🌲 Working Branch
feature/TOWNSCOOP-62
<!-- 작업 브랜치 이름 -->

#### ✅ TODOs

<!-- PR 작업한 내용 -->

- [x] 새로운 동네 등록 시 오류 수정
- [x] Response에 등록/해제 여부 포함

### Related Issues

<!-- PR 연관 이슈 -->

- resolves #62
