### PR TITLE
[#70]Feat: 가입시 동네 분위기 수집 및 동네 찾기시 '동네 분위기'정보 제공 기능 추가

### DIFF
--- a/YAPP-BE/src/main/java/yapp/common/config/Const.java
+++ b/YAPP-BE/src/main/java/yapp/common/config/Const.java
@@ -9,5 +9,6 @@ public class Const {
   public static final int QUIT_MEMBERS = 2;
   public static final String NON_USER = "Non-User";
 
+  public static final int MAX_RETRY = 4;
   public static final double DIVIDE_NUM = 2.0;
 }

--- a/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/controller/MemberController.java
@@ -39,8 +39,8 @@ public class MemberController {
   private final AuthTokenProvider tokenProvider;
 
   public MemberController(
-    MemberService memberService,
-    AuthTokenProvider tokenProvider
+          MemberService memberService,
+          AuthTokenProvider tokenProvider
   ) {
     this.memberService = memberService;
     this.tokenProvider = tokenProvider;
@@ -51,10 +51,10 @@ public class MemberController {
   @Operation(summary = "내 정보 확인")
   @Tag(name = "[화면]-마이페이지")
   public ApiResponse getMemberInfo(
-    @CurrentAuthPrincipal User memberPrincipal
+          @CurrentAuthPrincipal User memberPrincipal
   ) {
     MemberInfoResponse memberInfoResponse = this.memberService.getMemberInfo(
-      memberPrincipal.getUsername());
+            memberPrincipal.getUsername());
     return ApiResponse.success("member_info", memberInfoResponse);
   }
 
@@ -62,24 +62,24 @@ public class MemberController {
   @Operation(summary = "회원가입")
   @Tag(name = "[화면]-로그인/회원가입")
   public ApiResponse socialSignUp(
-    HttpServletRequest request,
-    HttpServletResponse response,
-    @RequestBody MemberSignUpRequest memberSignUpRequest
+          HttpServletRequest request,
+          HttpServletResponse response,
+          @RequestBody MemberSignUpRequest memberSignUpRequest
   ) {
     Map<String, Object> result = this.memberService.memberSignUp(memberSignUpRequest);
 
     // access_token 담기
     CookieUtil.deleteCookie(request, response, ACCESS_TOKEN);
     CookieUtil.addCookieForAccess(
-      response, ACCESS_TOKEN, String.valueOf(result.get("access_token")),
-      (Integer) result.get("cookie_max_age_for_access")
+            response, ACCESS_TOKEN, String.valueOf(result.get("access_token")),
+            (Integer) result.get("cookie_max_age_for_access")
     );
 
     // refresh_token 담기
     CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
     CookieUtil.addCookie(
-      response, REFRESH_TOKEN, String.valueOf(result.get("refresh_token")),
-      (Integer) result.get("cookie_max_age")
+            response, REFRESH_TOKEN, String.valueOf(result.get("refresh_token")),
+            (Integer) result.get("cookie_max_age")
     );
 
     return new ApiResponse(new ApiResponseHeader(200, "회원가입에 성공하였습니다."), result);
@@ -90,11 +90,11 @@ public class MemberController {
   @Operation(summary = "회원탈퇴")
   @Tag(name = "[화면]-마이페이지")
   public ApiResponse resignMember(
-    HttpServletRequest request,
-    @CurrentAuthPrincipal User memberPrincipal
+          HttpServletRequest request,
+          @CurrentAuthPrincipal User memberPrincipal
   ) {
     this.memberService.removeMember(
-      memberPrincipal.getUsername(), HeaderUtil.getAccessToken(request));
+            memberPrincipal.getUsername(), HeaderUtil.getAccessToken(request));
     return ApiResponse.success("resign_member", true);
   }
 
@@ -102,12 +102,12 @@ public class MemberController {
   @Operation(summary = "닉네임 중복 확인")
   @Tag(name = "[화면]-로그인/회원가입")
   public ApiResponse checkNickname(
-    @RequestParam(name = "nickname") String nickname
+          @RequestParam(name = "nickname") String nickname
   ) {
     boolean duplicateConfirm = this.memberService.checkDuplicateNickname(nickname);
 
     return duplicateConfirm ? ApiResponse.success("exist_confirm", true)
-      : ApiResponse.success("exist_confirm", false);
+            : ApiResponse.success("exist_confirm", false);
   }
 
   @PutMapping("/edit/nickname")
@@ -115,8 +115,8 @@ public class MemberController {
   @Operation(summary = "닉네임 수정 요청")
   @Tag(name = "[화면]-마이페이지")
   public ApiResponse editNickname(
-    @CurrentAuthPrincipal User memberPrincipal,
-    @RequestParam(name = "nickname") String nickname
+          @CurrentAuthPrincipal User memberPrincipal,
+          @RequestParam(name = "nickname") String nickname
   ) {
     this.memberService.editNickname(memberPrincipal.getUsername(), nickname);
     return ApiResponse.success("edit_nickname", true);
@@ -127,7 +127,7 @@ public class MemberController {
   @Operation(summary = "회원 가입 여부")
   @Tag(name = "[화면]-로그인/회원가입")
   public ApiResponse checkRegisterMember(
-    @CurrentAuthPrincipal User memberPrincipal
+          @CurrentAuthPrincipal User memberPrincipal
   ) {
     Map<String, Integer> result = new HashMap<>();
     int isRegister = this.memberService.checkRegister(memberPrincipal.getUsername());
@@ -149,8 +149,8 @@ public class MemberController {
   @Operation(summary = "로그 아웃")
   @Tag(name = "[화면]-마이페이지")
   public ApiResponse logout(
-    HttpServletRequest request,
-    @CurrentAuthPrincipal User memberPrincipal
+          HttpServletRequest request,
+          @CurrentAuthPrincipal User memberPrincipal
   ) {
     String accessToken = HeaderUtil.getAccessToken(request);
     AuthToken authToken = tokenProvider.convertAuthToken(accessToken);
@@ -167,7 +167,7 @@ public class MemberController {
   @Operation(summary = "찜 목록 조회")
   @Tag(name = "[화면]-찜")
   public ApiResponse getMemberWishTownList(
-    @CurrentAuthPrincipal User memberPrincipal
+          @CurrentAuthPrincipal User memberPrincipal
   ) {
 
     return ApiResponse.success(memberService.getMemberWishList(memberPrincipal.getUsername()));
@@ -178,11 +178,14 @@ public class MemberController {
   @Operation(summary = "찜 등록/해제")
   @Tag(name = "[화면]-찜")
   public ApiResponse setMemberWishTown(
-    @CurrentAuthPrincipal User memberPrincipal,
-    @RequestParam String object_id
+          @CurrentAuthPrincipal User memberPrincipal,
+          @RequestParam String object_id
   ) {
 
-    return ApiResponse.success("wishTown", this.memberService.setMemberWishTown(object_id, memberPrincipal.getUsername()));
+    return ApiResponse.success(
+            "wishTown",
+            this.memberService.setMemberWishTown(object_id, memberPrincipal.getUsername())
+    );
   }
 
 

--- a/YAPP-BE/src/main/java/yapp/domain/member/converter/MemberConverter.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/converter/MemberConverter.java
@@ -22,58 +22,60 @@ import yapp.domain.town.entity.TownResident;
 @RequiredArgsConstructor
 public class MemberConverter {
 
-  private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-  public MemberInfoResponse toMemberInfo(
-    Member member,
-    List<Location> locationList,
-    List<TownResident> townResidentList
-  ) {
-    return MemberInfoResponse.builder()
-      .memberId(member.getMemberId())
-      .email(member.getEmail())
-      .nickname(member.getNickname())
-      .resident(
-        townResidentList.stream().map(townResident ->
-          new Resident(
-            townResident.getResidentAddress(),
-            townResident.getResidentReview(),
-            townResident.getResidentYear(),
-            townResident.getResidentMonth()
-          )
-        ).collect(Collectors.toList()))
-      .useAgreeYn(member.getUseAgreeYn().getValue())
-      .privacyAgreeYn(member.getPrivacyAgreeYn().getValue())
-      .providerType(member.getProviderType())
-      .locationList(locationList
-        .stream()
-        .map(location -> {
-          return new LocationInfo(location.getObjectId(), location.getSidoNm(),
-            location.getSggNm(),
-            location.getAdmNm()
-          );
-        })
-        .collect(Collectors.toList())
-      )
-      .build();
-  }
+    public MemberInfoResponse toMemberInfo(
+            Member member,
+            List<Location> locationList,
+            List<TownResident> townResidentList
+    ) {
+        return MemberInfoResponse.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .resident(
+                        townResidentList.stream().map(townResident ->
+                                new Resident(
+                                        townResident.getResidentAddress(),
+                                        townResident.getResidentReview(),
+                                        townResident.getMoods().split(","),
+                                        townResident.getResidentYear(),
+                                        townResident.getResidentMonth()
+                                )
+                        ).collect(Collectors.toList()))
+                .useAgreeYn(member.getUseAgreeYn().getValue())
+                .privacyAgreeYn(member.getPrivacyAgreeYn().getValue())
+                .providerType(member.getProviderType())
+                .locationList(locationList
+                        .stream()
+                        .map(location -> {
+                            return new LocationInfo(location.getObjectId(), location.getSidoNm(),
+                                    location.getSggNm(),
+                                    location.getAdmNm()
+                            );
+                        })
+                        .collect(Collectors.toList())
+                )
+                .build();
+    }
 
-  public Member toEntity(
-    MemberSignUpRequest memberSignUpRequest
-  ) {
-    Member member = Member.builder()
-      .memberId(memberSignUpRequest.getMemberId())
-      .email(
-        StringUtils.hasText(memberSignUpRequest.getEmail()) ? memberSignUpRequest.getEmail()
-          : Const.DEFAULT_EMAIL)
-      .nickname(memberSignUpRequest.getNickname())
-      .providerType(memberSignUpRequest.getProviderType())
-      .useAgreeYn(YN.of(memberSignUpRequest.isUseAgreeYn()))
-      .privacyAgreeYn(YN.of(memberSignUpRequest.isPrivacyAgreeYn()))
-      .useStatus(Const.USE_MEMBERS)
-      .roleType(RoleType.USER)
-      .build();
-    member.encodeDefaultPassword(passwordEncoder);
-    return member;
-  }
+    public Member toEntity(
+            MemberSignUpRequest memberSignUpRequest
+    ) {
+        Member member = Member.builder()
+                .memberId(memberSignUpRequest.getMemberId())
+                .email(
+                        StringUtils.hasText(memberSignUpRequest.getEmail())
+                                ? memberSignUpRequest.getEmail()
+                                : Const.DEFAULT_EMAIL)
+                .nickname(memberSignUpRequest.getNickname())
+                .providerType(memberSignUpRequest.getProviderType())
+                .useAgreeYn(YN.of(memberSignUpRequest.isUseAgreeYn()))
+                .privacyAgreeYn(YN.of(memberSignUpRequest.isPrivacyAgreeYn()))
+                .useStatus(Const.USE_MEMBERS)
+                .roleType(RoleType.USER)
+                .build();
+        member.encodeDefaultPassword(passwordEncoder);
+        return member;
+    }
 }

--- a/YAPP-BE/src/main/java/yapp/domain/member/dto/response/TownReviewResponse.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/dto/response/TownReviewResponse.java
@@ -1,0 +1,16 @@
+package yapp.domain.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class TownReviewResponse {
+  private String residentAddress;
+  private String residentReview;
+  private String[] moods;
+  private int residentYear;
+  private int residentMonth;
+}

--- a/YAPP-BE/src/main/java/yapp/domain/member/entity/Resident.java
+++ b/YAPP-BE/src/main/java/yapp/domain/member/entity/Resident.java
@@ -11,19 +11,22 @@ public class Resident {
   private String residentAddress;
 
   private String residentReview;
+  private String[] moods;
 
   private int residentYear;
 
   private int residentMonth;
 
   public Resident(
-    String residentAddress,
-    String residentReview,
-    int residentYear,
-    int residentMonth
+          String residentAddress,
+          String residentReview,
+          String[] moods,
+          int residentYear,
+          int residentMonth
   ) {
     this.residentAddress = residentAddress;
     this.residentReview = residentReview;
+    this.moods = moods;
     this.residentYear = residentYear;
     this.residentMonth = residentMonth;
   }

--- a/YAPP-BE/src/main/java/yapp/domain/town/converter/TownConverter.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/converter/TownConverter.java
@@ -19,68 +19,69 @@ import yapp.domain.town.entity.TownHotPlace;
 public class TownConverter {
 
   public TownFilterResponse toFilterTown(
-    TownDto townDto,
-    Set<Long> memberWishTownList
+          TownDto townDto,
+          Set<Long> memberWishTownList
   ) {
     return TownFilterResponse.builder()
-      .objectId(townDto.getObjectId())
-      .townIntroduction(townDto.getTownIntroduction())
-      .safetyRate(townDto.getSafetyRate())
-      .lifeRate(townDto.getLifeRate())
-      .crimeRate(townDto.getCrimeRate())
-      .trafficRate(townDto.getTrafficRate())
-      .reliefYn(townDto.getReliefYn())
-      .wishTown(memberWishTownList.contains(townDto.getObjectId()))
-      .build();
+            .objectId(townDto.getObjectId())
+            .townIntroduction(townDto.getTownIntroduction())
+            .moods(townDto.getMoods())
+            .safetyRate(townDto.getSafetyRate())
+            .lifeRate(townDto.getLifeRate())
+            .crimeRate(townDto.getCrimeRate())
+            .trafficRate(townDto.getTrafficRate())
+            .reliefYn(townDto.getReliefYn())
+            .wishTown(memberWishTownList.contains(townDto.getObjectId()))
+            .build();
   }
 
   public TownSearchResponse toSearchTown(
-    Town town,
-    Set<Long> memberWishTownList
+          Town town,
+          Set<Long> memberWishTownList
   ) {
     return TownSearchResponse.builder()
-      .objectId(town.getObjectId())
-      .townIntroduction(town.getTownIntroduction())
-      .wishTown(memberWishTownList.contains(town.getObjectId()))
-      .build();
+            .objectId(town.getObjectId())
+            .townIntroduction(town.getTownIntroduction())
+            .wishTown(memberWishTownList.contains(town.getObjectId()))
+            .build();
   }
 
   public TownInfoResponse toTownDetailInfo(
-    TownDetailDto townDetailDto,
-    Set<Long> memberWishTownList
+          TownDetailDto townDetailDto,
+          Set<Long> memberWishTownList
   ) {
     return TownInfoResponse.builder()
-      .objectId(townDetailDto.getObjectId())
-      .townExplanation(townDetailDto.getTownDescribe())
-      .reliefYn(townDetailDto.getReliefYn().equals("Y") ? "안심마을보안관 활동지" : "")
-      .lifeRate(townDetailDto.getLifeRate())
-      .crimeRate(townDetailDto.getCrimeRate())
-      .trafficRate(townDetailDto.getTrafficRate())
-      .cleanlinessRank(townDetailDto.getCleanlinessRank())
-      .liveRank(townDetailDto.getLiveRank())
-      .popularTownRate(townDetailDto.getTownPopular().getPopularRate())
-      .popularGeneration(townDetailDto.getTownPopular().getPopularGeneration())
-      .townSubwayList(townDetailDto.getTownSubwayList()
-        .stream()
-        .map(Subway::getLineNum)
-        .distinct()
-        .collect(
-          Collectors.toList()))
-      .townMoodList(
-        townDetailDto.getTownMoodList()
-          .stream()
-          .map(Mood::getKeyword)
-          .distinct()
-          .collect(
-            Collectors.toList()))
-      .townHotPlaceList(townDetailDto.getTownHotPlaceList()
-        .stream()
-        .map(TownHotPlace::getHotPlaceNm)
-        .distinct()
-        .collect(
-          Collectors.toList()))
-      .wishTown(memberWishTownList.contains(townDetailDto.getObjectId()))
-      .build();
+            .objectId(townDetailDto.getObjectId())
+            .townExplanation(townDetailDto.getTownDescribe())
+            .reliefYn(townDetailDto.getReliefYn().equals("Y") ? "안심마을보안관 활동지" : "")
+            .lifeRate(townDetailDto.getLifeRate())
+            .crimeRate(townDetailDto.getCrimeRate())
+            .trafficRate(townDetailDto.getTrafficRate())
+            .cleanlinessRank(townDetailDto.getCleanlinessRank())
+            .liveRank(townDetailDto.getLiveRank())
+            .popularTownRate(townDetailDto.getTownPopular().getPopularRate())
+            .popularGeneration(townDetailDto.getTownPopular().getPopularGeneration())
+            .townSubwayList(townDetailDto.getTownSubwayList()
+                    .stream()
+                    .map(Subway::getLineNum)
+                    .distinct()
+                    .collect(
+                            Collectors.toList()))
+            .townMoodList(
+                    townDetailDto.getTownMoodList()
+                            .stream()
+                            .map(Mood::getKeyword)
+                            .distinct()
+                            .collect(
+                                    Collectors.toList()))
+            .townHotPlaceList(townDetailDto.getTownHotPlaceList()
+                    .stream()
+                    .map(TownHotPlace::getHotPlaceNm)
+                    .distinct()
+                    .collect(
+                            Collectors.toList()))
+            .wishTown(memberWishTownList.contains(townDetailDto.getObjectId()))
+            .build();
   }
 
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/converter/TownResidentConverter.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/converter/TownResidentConverter.java
@@ -10,16 +10,17 @@ import yapp.domain.town.entity.TownResident;
 public class TownResidentConverter {
 
   public TownResident toEntity(
-    MemberSignUpRequest memberSignUpRequest,
-    Long objectId
+          MemberSignUpRequest memberSignUpRequest,
+          Long objectId
   ) {
     return TownResident.builder()
-      .objectId(objectId)
-      .memberId(memberSignUpRequest.getMemberId())
-      .residentAddress(memberSignUpRequest.getResident().getResidentAddress())
-      .residentReview(memberSignUpRequest.getResident().getResidentReview())
-      .residentYear(memberSignUpRequest.getResident().getResidentYear())
-      .residentMonth(memberSignUpRequest.getResident().getResidentMonth())
-      .build();
+            .objectId(objectId)
+            .memberId(memberSignUpRequest.getMemberId())
+            .residentAddress(memberSignUpRequest.getResident().getResidentAddress())
+            .residentReview(memberSignUpRequest.getResident().getResidentReview())
+            .moods(String.join(",", memberSignUpRequest.getResident().getMoods()))
+            .residentYear(memberSignUpRequest.getResident().getResidentYear())
+            .residentMonth(memberSignUpRequest.getResident().getResidentMonth())
+            .build();
   }
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/dto/TownDto.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/dto/TownDto.java
@@ -13,6 +13,7 @@ public class TownDto {
   private Long objectId;
   private Place place;
   private TownSubway townSubway;
+  private String[] moods;
   private String reliefYn;
   private int lifeRate;
   private int crimeRate;
@@ -26,14 +27,14 @@ public class TownDto {
 
   @QueryProjection
   public TownDto(
-    Long objectId,
-    Place place,
-    TownSubway townSubway,
-    String reliefYn,
-    int lifeRate,
-    int crimeRate,
-    int trafficRate,
-    String townIntroduction
+          Long objectId,
+          Place place,
+          TownSubway townSubway,
+          String reliefYn,
+          int lifeRate,
+          int crimeRate,
+          int trafficRate,
+          String townIntroduction
   ) {
     this.objectId = objectId;
     this.place = place;

--- a/YAPP-BE/src/main/java/yapp/domain/town/dto/response/TownFilterResponse.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/dto/response/TownFilterResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class TownFilterResponse {
   private Long objectId;
   private String townIntroduction;
+  private String[] moods;
   private double safetyRate;
   private int lifeRate;
   private int crimeRate;

--- a/YAPP-BE/src/main/java/yapp/domain/town/entity/TownMood.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/entity/TownMood.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,4 +33,23 @@ public class TownMood {
   @JoinColumn(name = "mood_id", referencedColumnName = "id", nullable = false)
   private Mood mood;
 
+  @Column(name = "cnt", columnDefinition = "BIGINT")
+  private Long cnt;
+
+  @Version
+  private int version;
+
+  public TownMood(
+          Town town,
+          Mood mood,
+          Long cnt
+  ) {
+    this.town = town;
+    this.mood = mood;
+    this.cnt = cnt;
+  }
+
+  public void changeMoodCnt(Long cnt) {
+    this.cnt = cnt;
+  }
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/entity/TownResident.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/entity/TownResident.java
@@ -36,6 +36,9 @@ public class TownResident extends BaseEntity {
   @Column(name = "resident_review")
   private String residentReview;
 
+  @Column(name = "moods")
+  private String moods;
+
   @Column(name = "resident_year")
   private int residentYear;
 
@@ -48,25 +51,27 @@ public class TownResident extends BaseEntity {
 
   @Builder
   public TownResident(
-    Long seq,
-    Long objectId,
-    String memberId,
-    String residentAddress,
-    String residentReview,
-    int residentYear,
-    int residentMonth
+          Long seq,
+          Long objectId,
+          String memberId,
+          String residentAddress,
+          String residentReview,
+          String moods,
+          int residentYear,
+          int residentMonth
   ) {
     this.seq = seq;
     this.objectId = objectId;
     this.memberId = memberId;
     this.residentAddress = residentAddress;
     this.residentReview = residentReview;
+    this.moods = moods;
     this.residentYear = residentYear;
     this.residentMonth = residentMonth;
   }
 
   public static TownResident EmptyResident() {
-    return new TownResident(0L, 0L, "", "", "", 0, 0);
+    return new TownResident(0L, 0L, "", "", "", "", 0, 0);
   }
 
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/repository/MoodRepository.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/repository/MoodRepository.java
@@ -1,0 +1,11 @@
+package yapp.domain.town.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import yapp.domain.town.entity.Mood;
+
+@Repository
+public interface MoodRepository extends JpaRepository<Mood, Long> {
+  Optional<Mood> findByKeyword(String keyword);
+}

--- a/YAPP-BE/src/main/java/yapp/domain/town/repository/TownCustomRepository.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/repository/TownCustomRepository.java
@@ -9,19 +9,21 @@ import yapp.domain.town.entity.Town;
 public interface TownCustomRepository {
 
   List<TownDto> getTownFilterList(
-    FilterStatus filterStatus,
-    List<String> stationCondition
+          FilterStatus filterStatus,
+          List<String> stationCondition
   );
 
   List<Town> getTownSearchList(
-    String sggNm
+          String sggNm
   );
 
   List<TownDetailDto> getTownDetailInfo(
-    Long objectId
+          Long objectId
   );
 
   List<Town> getMemberWishTownList(
-    String memberId
+          String memberId
   );
+
+  List<Town> getTownByObjectId(Long objectId);
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/repository/TownCustomRepositoryImpl.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/repository/TownCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package yapp.domain.town.repository;
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 import static yapp.common.domain.QLocation.location;
+import static yapp.domain.member.entity.QMemberWishTown.memberWishTown;
 import static yapp.domain.member.entity.WishStatus.YES;
 import static yapp.domain.member.entity.YN.Y;
 import static yapp.domain.town.entity.QMood.mood;
@@ -14,14 +15,12 @@ import static yapp.domain.town.entity.QTownPopular.townPopular;
 import static yapp.domain.town.entity.QTownSubway.townSubway;
 import static yapp.domain.townMap.entity.QInfra.infra;
 import static yapp.domain.townMap.entity.QPlace.place;
-import static yapp.domain.member.entity.QMemberWishTown.memberWishTown;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import org.springframework.stereotype.Repository;
-import yapp.domain.member.entity.WishStatus;
 import yapp.domain.town.dto.QTownDto;
 import yapp.domain.town.dto.TownDetailDto;
 import yapp.domain.town.dto.TownDto;
@@ -34,147 +33,159 @@ import yapp.domain.town.entity.TownHotPlace;
 
 @Repository
 public class TownCustomRepositoryImpl implements
-  TownCustomRepository {
+        TownCustomRepository {
 
-  public JPAQueryFactory jpaQueryFactory;
+    public JPAQueryFactory jpaQueryFactory;
 
-  public TownCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
-    this.jpaQueryFactory = jpaQueryFactory;
-  }
+    public TownCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
 
-  @Override
-  public List<TownDto> getTownFilterList(
-    FilterStatus filterStatus,
-    List<String> stationCondition
-  ) {
-    return jpaQueryFactory
-      .select(
-        new QTownDto(
-          town.objectId,
-          place,
-          townSubway,
-          town.reliefYn,
-          town.lifeRate,
-          town.crimeRate,
-          town.trafficRate,
-          town.townIntroduction
-        )
-      )
-      .from(town)
-      .innerJoin(townSubway)
-      .on(town.objectId.eq(townSubway.town.objectId))
-      .leftJoin(subway)
-      .on(townSubway.subway.id.eq(subway.id))
-      .leftJoin(place)
-      .on(town.objectId.eq(place.objectId))
-      .leftJoin(infra)
-      .on(place.infra.id.eq(infra.id))
-      .where(town.useStatus.eq(Y), subwayContain(stationCondition), eqInfraType(filterStatus))
-      .fetch();
-  }
+    @Override
+    public List<TownDto> getTownFilterList(
+            FilterStatus filterStatus,
+            List<String> stationCondition
+    ) {
+        return jpaQueryFactory
+                .select(
+                        new QTownDto(
+                                town.objectId,
+                                place,
+                                townSubway,
+                                town.reliefYn,
+                                town.lifeRate,
+                                town.crimeRate,
+                                town.trafficRate,
+                                town.townIntroduction
+                        )
+                )
+                .from(town)
+                .innerJoin(townSubway)
+                .on(town.objectId.eq(townSubway.town.objectId))
+                .leftJoin(subway)
+                .on(townSubway.subway.id.eq(subway.id))
+                .leftJoin(place)
+                .on(town.objectId.eq(place.objectId))
+                .leftJoin(infra)
+                .on(place.infra.id.eq(infra.id))
+                .where(
+                        town.useStatus.eq(Y), subwayContain(stationCondition),
+                        eqInfraType(filterStatus)
+                )
+                .fetch();
+    }
 
-  @Override
-  public List<Town> getTownSearchList(
-    String sggNm
-  ) {
-    return jpaQueryFactory
-      .selectFrom(town)
-      .innerJoin(location)
-      .on(town.objectId.eq(location.objectId))
-      .where(location.sggNm.eq(sggNm), town.useStatus.eq(Y))
-      .fetch();
-  }
 
-  @Override
-  public List<TownDetailDto> getTownDetailInfo(Long objectId) {
-    return jpaQueryFactory
-      .from(town)
-      .leftJoin(townSubway)
-      .on(town.objectId.eq(townSubway.town.objectId))
-      .leftJoin(subway)
-      .on(townSubway.subway.id.eq(subway.id))
-      .leftJoin(townMood)
-      .on(town.objectId.eq(townMood.town.objectId))
-      .leftJoin(mood)
-      .on(townMood.mood.eq(mood))
-      .leftJoin(townPopular)
-      .on(town.objectId.eq(townPopular.objectId))
-      .leftJoin(townHotPlace)
-      .on(town.objectId.eq(townHotPlace.objectId))
-      .where(town.objectId.eq(objectId), town.useStatus.eq(Y))
-      .transform(
-        groupBy(town.objectId).list(
-          Projections.fields(
-            TownDetailDto.class,
-            town.objectId,
-            town.townDescribe,
-            town.reliefYn,
-            list(
-              Projections.fields(
-                Subway.class,
-                subway.id,
-                subway.lineNum
-              )
-            ).as("townSubwayList"),
-            list(
-              Projections.fields(
-                Mood.class,
-                mood.id,
-                mood.categoryId,
-                mood.categoryNm,
-                mood.keyword
-              )
-            ).as("townMoodList"),
-            townPopular,
-            list(
-              Projections.fields(
-                TownHotPlace.class,
-                townHotPlace.seq,
-                townHotPlace.objectId,
-                townHotPlace.hotPlaceNm
-              )
-            ).as("townHotPlaceList"),
-            town.lifeRate,
-            town.crimeRate,
-            town.trafficRate,
-            town.liveRank,
-            town.cleanlinessRank
-          )
-        )
-      );
-  }
+    @Override
+    public List<Town> getTownSearchList(
+            String sggNm
+    ) {
+        return jpaQueryFactory
+                .selectFrom(town)
+                .innerJoin(location)
+                .on(town.objectId.eq(location.objectId))
+                .where(location.sggNm.eq(sggNm), town.useStatus.eq(Y))
+                .fetch();
+    }
 
-  @Override
-  public List<Town> getMemberWishTownList(
-    String memberId
-  ) {
-    return jpaQueryFactory
-      .selectFrom(town)
-      .innerJoin(memberWishTown)
-      .on(town.objectId.eq(memberWishTown.location.objectId))
-      .where(memberWishTown.memberId.eq(memberId), memberWishTown.wishStatus.eq(YES))
-      .fetch();
-  }
+    @Override
+    public List<TownDetailDto> getTownDetailInfo(Long objectId) {
+        return jpaQueryFactory
+                .from(town)
+                .leftJoin(townSubway)
+                .on(town.objectId.eq(townSubway.town.objectId))
+                .leftJoin(subway)
+                .on(townSubway.subway.id.eq(subway.id))
+                .leftJoin(townMood)
+                .on(town.objectId.eq(townMood.town.objectId))
+                .leftJoin(mood)
+                .on(townMood.mood.eq(mood))
+                .leftJoin(townPopular)
+                .on(town.objectId.eq(townPopular.objectId))
+                .leftJoin(townHotPlace)
+                .on(town.objectId.eq(townHotPlace.objectId))
+                .where(town.objectId.eq(objectId), town.useStatus.eq(Y))
+                .transform(
+                        groupBy(town.objectId).list(
+                                Projections.fields(
+                                        TownDetailDto.class,
+                                        town.objectId,
+                                        town.townDescribe,
+                                        town.reliefYn,
+                                        list(
+                                                Projections.fields(
+                                                        Subway.class,
+                                                        subway.id,
+                                                        subway.lineNum
+                                                )
+                                        ).as("townSubwayList"),
+                                        list(
+                                                Projections.fields(
+                                                        Mood.class,
+                                                        mood.id,
+                                                        mood.categoryId,
+                                                        mood.categoryNm,
+                                                        mood.keyword
+                                                )
+                                        ).as("townMoodList"),
+                                        townPopular,
+                                        list(
+                                                Projections.fields(
+                                                        TownHotPlace.class,
+                                                        townHotPlace.seq,
+                                                        townHotPlace.objectId,
+                                                        townHotPlace.hotPlaceNm
+                                                )
+                                        ).as("townHotPlaceList"),
+                                        town.lifeRate,
+                                        town.crimeRate,
+                                        town.trafficRate,
+                                        town.liveRank,
+                                        town.cleanlinessRank
+                                )
+                        )
+                );
+    }
 
-  private BooleanBuilder subwayContain(List<String> stationCondition) {
-    BooleanBuilder builder = new BooleanBuilder();
-    stationCondition.forEach(lineNum -> {
-      builder.or(
-        subway.lineNum.eq(lineNum)
-      );
-    });
-    return builder;
-  }
+    @Override
+    public List<Town> getMemberWishTownList(
+            String memberId
+    ) {
+        return jpaQueryFactory
+                .selectFrom(town)
+                .innerJoin(memberWishTown)
+                .on(town.objectId.eq(memberWishTown.location.objectId))
+                .where(memberWishTown.memberId.eq(memberId), memberWishTown.wishStatus.eq(YES))
+                .fetch();
+    }
 
-  private BooleanBuilder eqInfraType(FilterStatus filterStatus) {
-    List<InfraStatus> infraStaticCondition = filterStatus.getInfraStatuses();
-    BooleanBuilder builder = new BooleanBuilder();
-    infraStaticCondition.forEach(infraStatus -> {
-      builder.or(
-        infra.subCategory.eq(infraStatus.getCode())
-      );
-    });
-    return builder;
-  }
+    @Override
+    public List<Town> getTownByObjectId(Long objectId) {
+        return jpaQueryFactory
+                .select(town)
+                .where(town.objectId.eq(objectId))
+                .fetch();
+    }
+
+    private BooleanBuilder subwayContain(List<String> stationCondition) {
+        BooleanBuilder builder = new BooleanBuilder();
+        stationCondition.forEach(lineNum -> {
+            builder.or(
+                    subway.lineNum.eq(lineNum)
+            );
+        });
+        return builder;
+    }
+
+    private BooleanBuilder eqInfraType(FilterStatus filterStatus) {
+        List<InfraStatus> infraStaticCondition = filterStatus.getInfraStatuses();
+        BooleanBuilder builder = new BooleanBuilder();
+        infraStaticCondition.forEach(infraStatus -> {
+            builder.or(
+                    infra.subCategory.eq(infraStatus.getCode())
+            );
+        });
+        return builder;
+    }
 
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/repository/TownMoodRepository.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/repository/TownMoodRepository.java
@@ -1,0 +1,18 @@
+package yapp.domain.town.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import yapp.domain.town.entity.TownMood;
+
+@Repository
+public interface TownMoodRepository extends JpaRepository<TownMood, Long> {
+
+  Optional<TownMood> findByTownObjectIdAndMoodKeyword(
+          Long townObjectId,
+          String moodKeyword
+  );
+
+  List<TownMood> findTop2ByTownObjectIdOrderByCntDesc(Long objectId);
+}

--- a/YAPP-BE/src/main/java/yapp/domain/town/repository/TownRepository.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/repository/TownRepository.java
@@ -1,6 +1,7 @@
 package yapp.domain.town.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import yapp.domain.member.entity.YN;
@@ -10,4 +11,6 @@ import yapp.domain.town.entity.Town;
 public interface TownRepository extends JpaRepository<Town, Long> {
 
   List<Town> findTownsByUseStatus(YN y);
+
+  Optional<Town> findTownByObjectId(Long objectId);
 }

--- a/YAPP-BE/src/main/java/yapp/domain/town/service/TownService.java
+++ b/YAPP-BE/src/main/java/yapp/domain/town/service/TownService.java
@@ -27,6 +27,7 @@ import yapp.domain.town.dto.response.TownSearchResponse;
 import yapp.domain.town.entity.FilterStatus;
 import yapp.domain.town.entity.Town;
 import yapp.domain.town.repository.TownCustomRepository;
+import yapp.domain.town.repository.TownMoodRepository;
 import yapp.exception.base.town.TownException.TownNotFound;
 
 @Slf4j
@@ -35,23 +36,26 @@ public class TownService {
 
   private final MemberWishTownRepository memberWishTownRepository;
   private final TownCustomRepository townCustomRepository;
+  private final TownMoodRepository townMoodRepository;
   private final TownConverter townConverter;
 
   public TownService(
-    MemberWishTownRepository memberWishTownRepository,
-    TownCustomRepository townCustomRepository,
-    TownConverter townConverter
+          MemberWishTownRepository memberWishTownRepository,
+          TownCustomRepository townCustomRepository,
+          TownMoodRepository townMoodRepository,
+          TownConverter townConverter
   ) {
     this.memberWishTownRepository = memberWishTownRepository;
     this.townCustomRepository = townCustomRepository;
+    this.townMoodRepository = townMoodRepository;
     this.townConverter = townConverter;
   }
 
   // 동네 필터
   @Transactional(readOnly = true)
   public List<TownFilterResponse> getTownFilter(
-    Optional<String> memberId,
-    TownFilterRequest townFilterRequest
+          Optional<String> memberId,
+          TownFilterRequest townFilterRequest
   ) {
     //인프라(편의시설, 운동, 의료시설, 녹지공간), 교통(호선 정보들), 회원 정보(찜 목록을 위한)  request
     Set<Long> memberWishTownList = new HashSet<>();
@@ -61,23 +65,35 @@ public class TownService {
 
     // 2. 인프라, 교통으로 동네 조회
     List<TownDto> townFilterList = townCustomRepository.getTownFilterList(
-      townFilterRequest.getFilterStatus(), townFilterRequest.getSubwayList());
+            townFilterRequest.getFilterStatus(), townFilterRequest.getSubwayList());
 
     // 2.5 동네 데이터 필터링
-    // - 동네별로 그룹화 
+    // - 동네별로 그룹화
     Map<Long, TownDto> townDataMap = new HashMap<>();
     townFilterList.forEach(
-      townData -> {
-        if (townDataMap.containsKey(townData.getObjectId())) {
-          townDataMap.get(townData.getObjectId()).getPlaceSet().add(townData.getPlace());
-          townDataMap.get(townData.getObjectId()).getTownSubwaySet().add(townData.getTownSubway());
-        } else {
-          townData.setTownSubwaySet(new HashSet<>());
-          townData.setPlaceSet(new HashSet<>());
-          townData.setSafetyRate((townData.getTrafficRate() + townData.getLifeRate()) / DIVIDE_NUM);
-          townDataMap.put(townData.getObjectId(), townData);
-        }
-      }
+            townData -> {
+              if (townDataMap.containsKey(townData.getObjectId())) {
+                townDataMap.get(townData.getObjectId())
+                        .getPlaceSet()
+                        .add(townData.getPlace());
+                townDataMap.get(townData.getObjectId())
+                        .getTownSubwaySet()
+                        .add(townData.getTownSubway());
+              } else {
+                // 2.7 townDto에 있는 objectId를 기준으로 상위 2개 동네 분위기를 조회한다.
+                String[] moods = this.townMoodRepository.findTop2ByTownObjectIdOrderByCntDesc(
+                                townData.getObjectId())
+                        .stream()
+                        .map(t -> t.getMood().getKeyword())
+                        .toArray(String[]::new);
+                townData.setMoods(moods);
+                townData.setTownSubwaySet(new HashSet<>());
+                townData.setPlaceSet(new HashSet<>());
+                townData.setSafetyRate(
+                        (townData.getTrafficRate() + townData.getLifeRate()) / DIVIDE_NUM);
+                townDataMap.put(townData.getObjectId(), townData);
+              }
+            }
     );
 
     // - filter type별 정렬
@@ -87,32 +103,32 @@ public class TownService {
     // - 찜 상태 등록
     Set<Long> finalMemberWishTownList = memberWishTownList;
     return townFilterList.stream()
-      .map(town -> townConverter.toFilterTown(town, finalMemberWishTownList))
-      .collect(Collectors.toList());
+            .map(town -> townConverter.toFilterTown(town, finalMemberWishTownList))
+            .collect(Collectors.toList());
   }
 
   @Transactional(readOnly = true)
   public List<TownSearchResponse> getTownSearch(
-    Optional<String> memberId,
-    TownSearchRequest townSearchRequest
+          Optional<String> memberId,
+          TownSearchRequest townSearchRequest
   ) {
 
     List<Town> townSearchList = townCustomRepository.getTownSearchList(
-      townSearchRequest.getSggNm());
+            townSearchRequest.getSggNm());
 
     Set<Long> memberWishTownList = new HashSet<>();
     memberWishTownList = getMemberWishTownList(memberId, memberWishTownList);
 
     Set<Long> finalMemberWishTownList = memberWishTownList;
     return townSearchList.stream()
-      .map(town -> townConverter.toSearchTown(town, finalMemberWishTownList))
-      .collect(Collectors.toList());
+            .map(town -> townConverter.toSearchTown(town, finalMemberWishTownList))
+            .collect(Collectors.toList());
   }
 
   @Transactional(readOnly = true)
   public TownInfoResponse getTownDetailInfo(
-    Optional<String> memberId,
-    Long objectId
+          Optional<String> memberId,
+          Long objectId
   ) {
     // 동내 조회
     Set<Long> memberWishTownList = new HashSet<>();
@@ -130,32 +146,40 @@ public class TownService {
   }
 
   private Set<Long> getMemberWishTownList(
-    Optional<String> memberId,
-    Set<Long> memberWishTownList
+          Optional<String> memberId,
+          Set<Long> memberWishTownList
   ) {
     if (memberId.isPresent()) {
       memberWishTownList = memberWishTownRepository.getMemberWishTownsByMemberIdAndWishStatus(
-          memberId.get(), WishStatus.YES)
-        .stream().map(town -> town.getLocation().getObjectId()).collect(Collectors.toSet());
+                      memberId.get(), WishStatus.YES)
+              .stream()
+              .map(town -> town.getLocation().getObjectId())
+              .collect(Collectors.toSet());
     }
     return memberWishTownList;
   }
 
   private void filterInfraType(
-    List<TownDto> townDtoList,
-    FilterStatus filterStatus
+          List<TownDto> townDtoList,
+          FilterStatus filterStatus
   ) {
     switch (filterStatus) {
       case MEDICAL_FACILITY_FILTER:
         townDtoList.stream()
-          .sorted(TownComparator.compareMedicalFilter)
-          .collect(Collectors.toList());
+                .sorted(TownComparator.compareMedicalFilter)
+                .collect(Collectors.toList());
       case EXERCISE_FILTER:
-        townDtoList.stream().sorted(TownComparator.compareTownFilter).collect(Collectors.toList());
+        townDtoList.stream()
+                .sorted(TownComparator.compareTownFilter)
+                .collect(Collectors.toList());
       case CONVENIENCE_FILTER:
-        townDtoList.stream().sorted(TownComparator.compareTownFilter).collect(Collectors.toList());
+        townDtoList.stream()
+                .sorted(TownComparator.compareTownFilter)
+                .collect(Collectors.toList());
       case GREENERY_FILTER:
-        townDtoList.stream().sorted(TownComparator.compareTownFilter).collect(Collectors.toList());
+        townDtoList.stream()
+                .sorted(TownComparator.compareTownFilter)
+                .collect(Collectors.toList());
       default:
     }
   }

--- a/YAPP-BE/src/main/java/yapp/exception/base/town/TownException.java
+++ b/YAPP-BE/src/main/java/yapp/exception/base/town/TownException.java
@@ -11,4 +11,10 @@ public class TownException {
     }
   }
 
+  public static class MoodNotFound extends BusinessException {
+    public MoodNotFound(String... message) {
+      super(ErrorCodes.ENTITY_NOT_FOUND(String.join(", ", message)));
+    }
+  }
+
 }


### PR DESCRIPTION
## 📝 PR Summary

<!-- PR 한줄 요약 -->
회원 가입시 동네 분위기 정보 수집과 동네 찾기 및 후기에서 동네 분위기 태그를 조회할 수 있다
#### 🌲 Working Branch

<!-- 작업 브랜치 이름 -->
feature/TOWNSCOOP-70

#### ✅ TODOs

<!-- PR 작업한 내용 -->

- [x] : 회원가입시 동네분위기 태그 입력 추가로 town_mood의 cnt값 증가에 따른 동시성을 고려한 로직 추가
- [x] : 동네 찾기시 상위 2개 분위기 태그 반환 추가
- [x] : 마이페이지에서 내가 작성한 동네 후기에 분위기 태그 반환 추가

### Related Issues

<!-- PR 연관 이슈 -->

- resolves #70 
